### PR TITLE
Feature/#34 채팅방 나가기 기능 구현

### DIFF
--- a/src/main/java/org/chatchat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/org/chatchat/chatmessage/controller/ChatMessageController.java
@@ -5,6 +5,7 @@ import org.chatchat.chatmessage.dto.request.MessageRequest;
 import org.chatchat.chatmessage.dto.response.MessageResponse;
 import org.chatchat.chatmessage.service.ChatMessageService;
 import org.chatchat.chatroom.dto.request.InviteUserToRoomRequest;
+import org.chatchat.chatroom.dto.request.LeaveRoomRequest;
 import org.chatchat.common.exception.UnauthorizedException;
 import org.chatchat.common.exception.type.ErrorType;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -21,17 +22,24 @@ public class ChatMessageController {
     private final SimpMessageSendingOperations messagingTemplate;
 
     @MessageMapping("/chat.sendMessage")
-    public void sendMessage(@Payload MessageRequest messageRequest, SimpMessageHeaderAccessor headerAccessor) {
+    public void sendTalkMessage(@Payload MessageRequest messageRequest, SimpMessageHeaderAccessor headerAccessor) {
         String username = extractUsername(headerAccessor);
-        MessageResponse messageResponse = chatMessageService.saveMessage(messageRequest, username);
+        MessageResponse messageResponse = chatMessageService.saveTalkMessage(messageRequest, username);
         messagingTemplate.convertAndSend("/topic/room." + messageRequest.roomId(), messageResponse);
     }
 
     @MessageMapping("/chat.sendInviteMessage")
     public void sendInviteMessage(@Payload InviteUserToRoomRequest inviteUserToRoomRequest, SimpMessageHeaderAccessor headerAccessor) {
         String username = extractUsername(headerAccessor);
-        MessageResponse messageResponse = chatMessageService.sendSystemMessage(inviteUserToRoomRequest, username);
+        MessageResponse messageResponse = chatMessageService.saveInviteMessage(inviteUserToRoomRequest, username);
         messagingTemplate.convertAndSend("/topic/room." + inviteUserToRoomRequest.roomId(), messageResponse);
+    }
+
+    @MessageMapping("/chat.sendLeaveMessage")
+    public void sendLeaveMessage(@Payload LeaveRoomRequest leaveRoomRequest, SimpMessageHeaderAccessor headerAccessor) {
+        String username = extractUsername(headerAccessor);
+        MessageResponse messageResponse = chatMessageService.saveLeaveMessage(leaveRoomRequest, username);
+        messagingTemplate.convertAndSend("/topic/room." + leaveRoomRequest.roomId(), messageResponse);
     }
 
     private String extractUsername(SimpMessageHeaderAccessor headerAccessor) {

--- a/src/main/java/org/chatchat/chatmessage/domain/ChatMessage.java
+++ b/src/main/java/org/chatchat/chatmessage/domain/ChatMessage.java
@@ -3,6 +3,7 @@ package org.chatchat.chatmessage.domain;
 import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ public class ChatMessage {
     @Id
     private String id;
     private MessageType type;
+    @Indexed
     private String roomId;
     private String sender;
     private String content;

--- a/src/main/java/org/chatchat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/org/chatchat/chatmessage/service/ChatMessageService.java
@@ -8,6 +8,7 @@ import org.chatchat.chatmessage.dto.request.MessageRequest;
 import org.chatchat.chatmessage.dto.response.MessageResponse;
 import org.chatchat.chatroom.domain.Room;
 import org.chatchat.chatroom.dto.request.InviteUserToRoomRequest;
+import org.chatchat.chatroom.dto.request.LeaveRoomRequest;
 import org.chatchat.chatroom.service.RoomQueryService;
 import org.springframework.stereotype.Service;
 
@@ -23,7 +24,7 @@ public class ChatMessageService {
     /**
      * 채팅 메세지 저장
      */
-    public MessageResponse saveMessage(MessageRequest messageRequest, String username) {
+    public MessageResponse saveTalkMessage(MessageRequest messageRequest, String username) {
         Room room = roomQueryService.findExistingRoomById(messageRequest.roomId());
         String content = messageRequest.message();
 
@@ -42,9 +43,28 @@ public class ChatMessageService {
     /**
      * 초대 메세지 저장
      */
-    public MessageResponse sendSystemMessage(InviteUserToRoomRequest inviteUserToRoomRequest, String username) {
+    public MessageResponse saveInviteMessage(InviteUserToRoomRequest inviteUserToRoomRequest, String username) {
         Room room = roomQueryService.findExistingRoomById(inviteUserToRoomRequest.roomId());
         String content = username + "님이 " + inviteUserToRoomRequest.username() + "님을 초대했습니다.";
+
+        ChatMessage chatMessage = ChatMessage.builder()
+                .type(MessageType.SYSTEM)
+                .roomId(String.valueOf(room.getId()))
+                .sender("시스템")
+                .content(content)
+                .sentAt(LocalDateTime.now())
+                .build();
+        ChatMessage saveMessage = chatMessageRepository.save(chatMessage);
+
+        return MessageResponse.from(saveMessage);
+    }
+
+    /**
+     * 나가기 메세지 저장
+     */
+    public MessageResponse saveLeaveMessage(LeaveRoomRequest leaveRoomRequest, String username) {
+        Room room = roomQueryService.findExistingRoomById(leaveRoomRequest.roomId());
+        String content = username + "님이 나갔습니다.";
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .type(MessageType.SYSTEM)

--- a/src/main/java/org/chatchat/chatmessage/util/WebSocketEventListener.java
+++ b/src/main/java/org/chatchat/chatmessage/util/WebSocketEventListener.java
@@ -2,14 +2,11 @@ package org.chatchat.chatmessage.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.chatchat.chatmessage.domain.ChatMessage;
-import org.chatchat.chatmessage.domain.MessageType;
 import org.chatchat.common.exception.InternalServerException;
 import org.chatchat.common.exception.UnauthorizedException;
 import org.chatchat.common.exception.type.ErrorType;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
@@ -20,13 +17,10 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 @RequiredArgsConstructor
 public class WebSocketEventListener {
 
-    private final SimpMessageSendingOperations messagingTemplate;
-
     // 웹소켓 연결 시 호출되는 메서드
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
-        log.info("New WebSocket connection established.");
-        log.info("event.getMessage(): {}", event.getMessage());
+        log.info("새로운 웹소켓 연결이 있습니다.");
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap((Message<?>) event.getMessage().getHeaders().get("simpConnectMessage"));
         try {
             String username = (String) headerAccessor.getSessionAttributes().get("username");
@@ -42,23 +36,12 @@ public class WebSocketEventListener {
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap((Message<?>) event.getMessage().getHeaders().get("simpConnectMessage"));
-        try {
-            String username = (String) headerAccessor.getSessionAttributes().get("username");
-            if (username == null) {
-                throw new UnauthorizedException(ErrorType.NO_AUTHORIZATION_ERROR, "세션에 username 이 비어있습니다.");
-            }
-            Long roomId = (Long) headerAccessor.getSessionAttributes().get("roomId");
-
-            log.info("User Disconnected: {}", username);
-            ChatMessage chatMessage = ChatMessage.builder()
-                    .type(MessageType.LEAVE)
-                    .roomId(String.valueOf(roomId))
-                    .sender(username)
-                    .content(username + " 님의 연결이 종료되었습니다.")
-                    .build();
-            messagingTemplate.convertAndSend("/topic/public", chatMessage);
-        } catch (Exception e) {
-            throw new InternalServerException(ErrorType.INTERNAL_SERVER_ERROR, e.getMessage());
+        String username = (String) headerAccessor.getSessionAttributes().get("username");
+        Long roomId = (Long) headerAccessor.getSessionAttributes().get("roomId");
+        if (username != null) {
+            log.info(username + "님이 " + roomId + "번 방의 소켓 연결을 끊었습니다.");
+        } else {
+            log.info("세션에 username 이 비어있는 유저의 웹소켓 연결이 끊어졌습니다.");
         }
     }
 }

--- a/src/main/java/org/chatchat/chatmessage/util/WebSocketInterceptor.java
+++ b/src/main/java/org/chatchat/chatmessage/util/WebSocketInterceptor.java
@@ -69,5 +69,4 @@ public class WebSocketInterceptor extends HttpSessionHandshakeInterceptor {
         }
         return null;
     }
-
 }

--- a/src/main/java/org/chatchat/chatpart/domain/repository/ChatPartRepository.java
+++ b/src/main/java/org/chatchat/chatpart/domain/repository/ChatPartRepository.java
@@ -3,7 +3,11 @@ package org.chatchat.chatpart.domain.repository;
 import org.chatchat.chatpart.domain.ChatPart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
 
     boolean existsByRoomIdAndUserId(Long roomId, Long userId);
+
+    Optional<ChatPart> findByRoomIdAndUserId(Long roomId, Long userId);
 }

--- a/src/main/java/org/chatchat/chatpart/service/ChatPartQueryService.java
+++ b/src/main/java/org/chatchat/chatpart/service/ChatPartQueryService.java
@@ -1,10 +1,14 @@
 package org.chatchat.chatpart.service;
 
 import lombok.RequiredArgsConstructor;
+import org.chatchat.chatpart.domain.ChatPart;
 import org.chatchat.chatpart.domain.repository.ChatPartRepository;
 import org.chatchat.common.exception.ConflictException;
+import org.chatchat.common.exception.ForbiddenException;
 import org.springframework.stereotype.Service;
+
 import static org.chatchat.common.exception.type.ErrorType.ALREADY_JOINED_USER_ERROR;
+import static org.chatchat.common.exception.type.ErrorType.NOT_ROOM_MEMBER_ERROR;
 
 @Service
 @RequiredArgsConstructor
@@ -16,5 +20,10 @@ public class ChatPartQueryService {
         if (chatPartRepository.existsByRoomIdAndUserId(roomId, userId)) {
             throw new ConflictException(ALREADY_JOINED_USER_ERROR);
         }
+    }
+
+    public ChatPart findExistingChatPartByRoomIdAndUserId(Long roomId, Long userId) {
+        return chatPartRepository.findByRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new ForbiddenException(NOT_ROOM_MEMBER_ERROR));
     }
 }

--- a/src/main/java/org/chatchat/chatpart/service/ChatPartQueryService.java
+++ b/src/main/java/org/chatchat/chatpart/service/ChatPartQueryService.java
@@ -3,11 +3,9 @@ package org.chatchat.chatpart.service;
 import lombok.RequiredArgsConstructor;
 import org.chatchat.chatpart.domain.ChatPart;
 import org.chatchat.chatpart.domain.repository.ChatPartRepository;
-import org.chatchat.common.exception.ConflictException;
 import org.chatchat.common.exception.ForbiddenException;
 import org.springframework.stereotype.Service;
 
-import static org.chatchat.common.exception.type.ErrorType.ALREADY_JOINED_USER_ERROR;
 import static org.chatchat.common.exception.type.ErrorType.NOT_ROOM_MEMBER_ERROR;
 
 @Service
@@ -17,8 +15,8 @@ public class ChatPartQueryService {
     private final ChatPartRepository chatPartRepository;
 
     public void isUserMemberOfRoom(Long roomId, Long userId) {
-        if (chatPartRepository.existsByRoomIdAndUserId(roomId, userId)) {
-            throw new ConflictException(ALREADY_JOINED_USER_ERROR);
+        if (!chatPartRepository.existsByRoomIdAndUserId(roomId, userId)) {
+            throw new ForbiddenException(NOT_ROOM_MEMBER_ERROR);
         }
     }
 

--- a/src/main/java/org/chatchat/chatpart/service/ChatPartService.java
+++ b/src/main/java/org/chatchat/chatpart/service/ChatPartService.java
@@ -7,13 +7,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ChatPartService {
 
     private final ChatPartRepository chatPartRepository;
 
-    @Transactional
     public void saveChatPart(final ChatPart chatPart) {
         chatPartRepository.save(chatPart);
+    }
+
+    public void removeChatPart(final ChatPart chatPart) {
+        chatPartRepository.delete(chatPart);
     }
 }

--- a/src/main/java/org/chatchat/chatroom/controller/RoomController.java
+++ b/src/main/java/org/chatchat/chatroom/controller/RoomController.java
@@ -37,7 +37,7 @@ public class RoomController {
         return ResponseEntity.ok(rooms);
     }
 
-    // 채팅방 입장 및 이전 메시지 불러오기
+    // 채팅방 입장
     @GetMapping("/{roomId}/enter")
     public ResponseEntity<PageResponseDto<MessageResponse>> enterRoom(@PathVariable("roomId") Long roomId,
                                                                       @RequestParam(defaultValue = "0") int page,
@@ -49,8 +49,9 @@ public class RoomController {
     // 채팅방 초대
     @PostMapping("/{roomId}/invite")
     public ResponseEntity<Void> inviteUserToRoom(@PathVariable Long roomId,
+                                                 @AuthUser User user,
                                                  @RequestBody @Valid InviteUserToRoomRequest inviteRequest) {
-        roomService.inviteUserToRoom(roomId, inviteRequest.username());
+        roomService.inviteUserToRoom(roomId, user.getId(), inviteRequest.username());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/chatchat/chatroom/controller/RoomController.java
+++ b/src/main/java/org/chatchat/chatroom/controller/RoomController.java
@@ -50,7 +50,15 @@ public class RoomController {
     @PostMapping("/{roomId}/invite")
     public ResponseEntity<Void> inviteUserToRoom(@PathVariable Long roomId,
                                                  @RequestBody @Valid InviteUserToRoomRequest inviteRequest) {
-        roomService.inviteUserToRoom(roomId, inviteRequest);
+        roomService.inviteUserToRoom(roomId, inviteRequest.username());
+        return ResponseEntity.ok().build();
+    }
+
+    // 채팅방 나가기
+    @DeleteMapping("/{roomId}/leave")
+    public ResponseEntity<Void> leaveRoom(@PathVariable Long roomId,
+                                          @AuthUser User user) {
+        roomService.leaveRoom(roomId, user.getId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/chatchat/chatroom/dto/request/LeaveRoomRequest.java
+++ b/src/main/java/org/chatchat/chatroom/dto/request/LeaveRoomRequest.java
@@ -1,0 +1,6 @@
+package org.chatchat.chatroom.dto.request;
+
+public record LeaveRoomRequest(
+        Long roomId
+) {
+}

--- a/src/main/java/org/chatchat/chatroom/service/RoomService.java
+++ b/src/main/java/org/chatchat/chatroom/service/RoomService.java
@@ -7,7 +7,6 @@ import org.chatchat.chatpart.service.ChatPartService;
 import org.chatchat.chatroom.domain.Room;
 import org.chatchat.chatroom.domain.repository.RoomRepository;
 import org.chatchat.chatroom.dto.request.CreateRoomRequest;
-import org.chatchat.chatroom.dto.request.InviteUserToRoomRequest;
 import org.chatchat.user.domain.User;
 import org.chatchat.user.service.UserQueryService;
 import org.springframework.stereotype.Service;
@@ -38,13 +37,13 @@ public class RoomService {
     /**
      * 채팅방 초대
      */
-    public void inviteUserToRoom(Long roomId, String username) {
+    public void inviteUserToRoom(Long roomId, Long userId, String username) {
         Room room = roomQueryService.findExistingRoomById(roomId);
+        // 이미 채팅방에 참여 중인 유저 검증
+        chatPartQueryService.isUserMemberOfRoom(roomId, userId);
+
         // 초대할 유저
         User inviteUser = userQueryService.findExistingUserByName(username);
-        // 이미 채팅방에 참여 중인 유저 검증
-        chatPartQueryService.isUserMemberOfRoom(roomId, inviteUser.getId());
-
         ChatPart chatPart = new ChatPart(room, inviteUser);
         chatPartService.saveChatPart(chatPart);
     }

--- a/src/main/java/org/chatchat/chatroom/service/RoomService.java
+++ b/src/main/java/org/chatchat/chatroom/service/RoomService.java
@@ -38,13 +38,22 @@ public class RoomService {
     /**
      * 채팅방 초대
      */
-    public void inviteUserToRoom(Long roomId, InviteUserToRoomRequest inviteUserToRoomRequest) {
+    public void inviteUserToRoom(Long roomId, String username) {
         Room room = roomQueryService.findExistingRoomById(roomId);
-        User inviteUser = userQueryService.findExistingUserByName(inviteUserToRoomRequest.username());
+        // 초대할 유저
+        User inviteUser = userQueryService.findExistingUserByName(username);
         // 이미 채팅방에 참여 중인 유저 검증
         chatPartQueryService.isUserMemberOfRoom(roomId, inviteUser.getId());
 
         ChatPart chatPart = new ChatPart(room, inviteUser);
         chatPartService.saveChatPart(chatPart);
+    }
+
+    /**
+     * 채팅방 나가기
+     */
+    public void leaveRoom(Long roomId, Long userId) {
+        ChatPart chatPart = chatPartQueryService.findExistingChatPartByRoomIdAndUserId(roomId, userId);
+        chatPartService.removeChatPart(chatPart);
     }
 }

--- a/src/main/java/org/chatchat/common/exception/type/ErrorType.java
+++ b/src/main/java/org/chatchat/common/exception/type/ErrorType.java
@@ -33,6 +33,7 @@ public enum ErrorType {
     ROOM_NOT_FOUND_ERROR("ROOM_40400", "채팅방을 찾을 수 없습니다."),
     DUPLICATED_ROOM_NAME_ERROR("ROOM_40900", "이미 사용 중인 채팅방 이름입니다."),
     ALREADY_JOINED_USER_ERROR("ROOM_40901", "이미 참가한 채팅방입니다."),
+    NOT_ROOM_MEMBER_ERROR("ROOM_40300", "채팅방의 멤버가 아닙니다."),
 
     // Resource
     NO_RESOURCE_ERROR( "RESOURCE_40000", "해당 리소스를 찾을 수 없습니다."),


### PR DESCRIPTION
## Description
- 채팅방 나가기 기능 구현
- 채팅 메세지 조회 성능 향상을 위한 MongoDB 인덱싱 추가
## Changes
### Controller
- [x] RoomController
- [x] ChatMessageController
### Service
- [x] RoomService
- [x] ChatMessageService
- [x] ChatPartService
- [x] ChatPartQueryService
### Domain
- [x] ChatMessage
### yml
- [x] application-local.yml
### Dto
- [x] LeaveRoomRequest
## Additional context
- 인덱스가 없는 MongoDB는 컬렉션의 모든 문서를 스캔한 후 쿼리 결과를 반환한다.
- 쿼리에 적합한 인덱스가 있는 경우 MongoDB는 인덱스를 사용하여 스캔해야하는 문서 수를 제한해준다.
- 채팅방 Id를 통한 ChatMessage 조회가 많으므로 ChatMessage roomId 필드에 @Indexed 어노테이션을 추가
- yml 파일에 `Spring.data.mongodb.auto-index-creation : true` 설정 추가로 @Document 어노테이션이 붙은 클래스의 필드 중 @Indexed 어노테이션이 붙은 필드에 인덱싱 적용된다.
Closes #34 
Closes #36 