### PR TITLE
Feature/#43 가장 최근에 채팅이 있던 채팅방 순으로 정렬하게끔 수정

### DIFF
--- a/src/main/java/org/chatchat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/org/chatchat/chatmessage/service/ChatMessageService.java
@@ -27,6 +27,8 @@ public class ChatMessageService {
     public MessageResponse saveTalkMessage(MessageRequest messageRequest, String username) {
         Room room = roomQueryService.findExistingRoomById(messageRequest.roomId());
         String content = messageRequest.message();
+        LocalDateTime now = LocalDateTime.now();
+        room.updateLastMessageTime(now);
 
         return getMessageResponse(MessageType.TALK, room, username, content);
     }

--- a/src/main/java/org/chatchat/room/domain/Room.java
+++ b/src/main/java/org/chatchat/room/domain/Room.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.chatchat.roomuser.domain.RoomUser;
 import org.chatchat.common.entity.BaseEntity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,10 +23,17 @@ public class Room extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column
+    private LocalDateTime lastMessageTime;  // 최근 메시지 시간 필드 추가
+
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<RoomUser> users = new ArrayList<>();
 
     public Room(String name) {
         this.name = name;
+    }
+
+    public void updateLastMessageTime(LocalDateTime time) {
+        this.lastMessageTime = time;
     }
 }

--- a/src/main/java/org/chatchat/room/domain/repository/RoomRepository.java
+++ b/src/main/java/org/chatchat/room/domain/repository/RoomRepository.java
@@ -13,6 +13,6 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     boolean existsByName(String name);
 
     // 참여 중인 채팅방 전체 조회
-    @Query("SELECT r FROM Room r JOIN r.users u WHERE u.user.id = :userId")
-    Page<Room> findByUserId(@Param("userId") Long userId, Pageable pageable);
+    @Query("SELECT r FROM Room r JOIN r.users u WHERE u.user.id = :userId ORDER BY r.lastMessageTime DESC")
+    Page<Room> findByUserIdOrderedByLastChatDesc(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/org/chatchat/room/service/RoomQueryService.java
+++ b/src/main/java/org/chatchat/room/service/RoomQueryService.java
@@ -29,7 +29,7 @@ public class RoomQueryService {
         PageRequestDto pageRequestDto = new PageRequestDto(page);
         Pageable pageable = pageRequestDto.toRoomPageable();
 
-        Page<Room> roomPage = roomRepository.findByUserId(userId, pageable);
+        Page<Room> roomPage = roomRepository.findByUserIdOrderedByLastChatDesc(userId, pageable);
         List<RoomInfoResponse> roomResponses = roomPage.getContent().stream()
                 .map(room -> new RoomInfoResponse(room.getId(), room.getName()))
                 .toList();


### PR DESCRIPTION
## Description
- 가장 최근에 채팅이 있던 채팅방 순으로 정렬하게끔 수정
## Changes
### Service
- [x] ChatMessageService
- [x] RoomQueryService
### domain
- [x] Room
- [x] RoomRepository
## Additional context
- 현재는 본인이 참여하고 있는 채팅방으로 조회됐다면 이제 가장 최근에 대화가 있었던 채팅방 순으로 정렬하고자 함.
- 가장 최근에 저장된 ChatMessage 값을 토대로 정렬? -> ChatMessage sentAt 필드가 있지만 NoSQL에 저장되는만큼 Room 이 저장되는 RDBMS와 조인을 통해 조회해야한다. 그럼 성능저하됨.
- Room 테이블에 lastMessageTime 필든 추가하여 메세지를 보낼 때마다 시간을 업데이트, 이 순서로 정렬함.
Closes #43