### PR TITLE
Feature/#45 채팅방별 읽지 않은 채팅 메세지 수 카운트 기능 구현

### DIFF
--- a/src/main/java/org/chatchat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/org/chatchat/chatmessage/controller/ChatMessageController.java
@@ -5,7 +5,7 @@ import org.chatchat.chatmessage.dto.request.MessageRequest;
 import org.chatchat.chatmessage.dto.response.MessageResponse;
 import org.chatchat.chatmessage.service.ChatMessageService;
 import org.chatchat.room.dto.request.InviteUserToRoomRequest;
-import org.chatchat.room.dto.request.LeaveRoomRequest;
+import org.chatchat.room.dto.request.QuitRoomRequest;
 import org.chatchat.common.exception.UnauthorizedException;
 import org.chatchat.common.exception.type.ErrorType;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -35,11 +35,11 @@ public class ChatMessageController {
         messagingTemplate.convertAndSend("/topic/room." + inviteUserToRoomRequest.roomId(), messageResponse);
     }
 
-    @MessageMapping("/chat.sendLeaveMessage")
-    public void sendLeaveMessage(@Payload LeaveRoomRequest leaveRoomRequest, SimpMessageHeaderAccessor headerAccessor) {
+    @MessageMapping("/chat.sendQuitMessage")
+    public void sendLeaveMessage(@Payload QuitRoomRequest quitRoomRequest, SimpMessageHeaderAccessor headerAccessor) {
         String username = extractUsername(headerAccessor);
-        MessageResponse messageResponse = chatMessageService.saveLeaveMessage(leaveRoomRequest, username);
-        messagingTemplate.convertAndSend("/topic/room." + leaveRoomRequest.roomId(), messageResponse);
+        MessageResponse messageResponse = chatMessageService.saveQuitMessage(quitRoomRequest, username);
+        messagingTemplate.convertAndSend("/topic/room." + quitRoomRequest.roomId(), messageResponse);
     }
 
     private String extractUsername(SimpMessageHeaderAccessor headerAccessor) {

--- a/src/main/java/org/chatchat/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/org/chatchat/chatmessage/service/ChatMessageService.java
@@ -8,8 +8,9 @@ import org.chatchat.chatmessage.dto.request.MessageRequest;
 import org.chatchat.chatmessage.dto.response.MessageResponse;
 import org.chatchat.room.domain.Room;
 import org.chatchat.room.dto.request.InviteUserToRoomRequest;
-import org.chatchat.room.dto.request.LeaveRoomRequest;
+import org.chatchat.room.dto.request.QuitRoomRequest;
 import org.chatchat.room.service.RoomQueryService;
+import org.chatchat.roomuser.service.RoomUserService;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -20,15 +21,17 @@ public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final RoomQueryService roomQueryService;
+    private final RoomUserService roomUserService;
 
     /**
      * 채팅 메세지 저장
      */
     public MessageResponse saveTalkMessage(MessageRequest messageRequest, String username) {
-        Room room = roomQueryService.findExistingRoomById(messageRequest.roomId());
+        Room room = roomQueryService.findExistingRoomByRoomId(messageRequest.roomId());
         String content = messageRequest.message();
         LocalDateTime now = LocalDateTime.now();
         room.updateLastMessageTime(now);
+        roomUserService.increaseUnreadMessageCount(room.getId(), username);
 
         return getMessageResponse(MessageType.TALK, room, username, content);
     }
@@ -37,7 +40,7 @@ public class ChatMessageService {
      * 초대 메세지 저장
      */
     public MessageResponse saveInviteMessage(InviteUserToRoomRequest inviteUserToRoomRequest, String username) {
-        Room room = roomQueryService.findExistingRoomById(inviteUserToRoomRequest.roomId());
+        Room room = roomQueryService.findExistingRoomByRoomId(inviteUserToRoomRequest.roomId());
         String content = username + "님이 " + inviteUserToRoomRequest.username() + "님을 초대했습니다.";
         String name = "시스템";
 
@@ -47,8 +50,8 @@ public class ChatMessageService {
     /**
      * 나가기 메세지 저장
      */
-    public MessageResponse saveLeaveMessage(LeaveRoomRequest leaveRoomRequest, String username) {
-        Room room = roomQueryService.findExistingRoomById(leaveRoomRequest.roomId());
+    public MessageResponse saveQuitMessage(QuitRoomRequest quitRoomRequest, String username) {
+        Room room = roomQueryService.findExistingRoomByRoomId(quitRoomRequest.roomId());
         String content = username + "님이 나갔습니다.";
         String name = "시스템";
 

--- a/src/main/java/org/chatchat/common/exception/type/ErrorType.java
+++ b/src/main/java/org/chatchat/common/exception/type/ErrorType.java
@@ -32,8 +32,11 @@ public enum ErrorType {
     // Room
     ROOM_NOT_FOUND_ERROR("ROOM_40400", "채팅방을 찾을 수 없습니다."),
     DUPLICATED_ROOM_NAME_ERROR("ROOM_40900", "이미 사용 중인 채팅방 이름입니다."),
-    ALREADY_JOINED_USER_ERROR("ROOM_40901", "이미 참가한 채팅방입니다."),
-    NOT_ROOM_MEMBER_ERROR("ROOM_40300", "채팅방의 멤버가 아닙니다."),
+
+    // RoomUser
+    NO_PARTICIPANT_ROOM_ERROR("ROOM_USER_40400", "해당 채팅방에 참여자가 없습니다."),
+    ALREADY_JOINED_USER_ERROR("ROOM_USER_40900", "이미 참가한 채팅방입니다."),
+    NOT_ROOM_MEMBER_ERROR("ROOM_USER_40300", "채팅방의 멤버가 아닙니다."),
 
     // Resource
     NO_RESOURCE_ERROR( "RESOURCE_40000", "해당 리소스를 찾을 수 없습니다."),

--- a/src/main/java/org/chatchat/room/controller/RoomController.java
+++ b/src/main/java/org/chatchat/room/controller/RoomController.java
@@ -2,8 +2,6 @@ package org.chatchat.room.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.chatchat.chatmessage.dto.response.MessageResponse;
-import org.chatchat.chatmessage.service.ChatMessageQueryService;
 import org.chatchat.room.dto.request.CreateRoomRequest;
 import org.chatchat.room.dto.request.InviteUserToRoomRequest;
 import org.chatchat.room.dto.response.RoomInfoResponse;
@@ -23,7 +21,6 @@ public class RoomController {
 
     private final RoomService roomService;
     private final RoomQueryService roomQueryService;
-    private final ChatMessageQueryService chatMessageQueryService;
 
     // 채팅방 생성
     @PostMapping
@@ -41,15 +38,6 @@ public class RoomController {
         return ResponseEntity.ok(rooms);
     }
 
-    // 채팅방 입장
-    @GetMapping("/{roomId}/enter")
-    public ResponseEntity<PageResponseDto<MessageResponse>> enterRoom(@PathVariable("roomId") Long roomId,
-                                                                      @RequestParam(defaultValue = "0") int page,
-                                                                      @AuthUser User user) {
-        PageResponseDto<MessageResponse> messages = chatMessageQueryService.loadMessagesByRoomId(roomId, user.getId(), page);
-        return ResponseEntity.ok(messages);
-    }
-
     // 채팅방 초대
     @PostMapping("/{roomId}/invite")
     public ResponseEntity<Void> inviteUserToRoom(@PathVariable Long roomId,
@@ -60,10 +48,10 @@ public class RoomController {
     }
 
     // 채팅방 나가기
-    @DeleteMapping("/{roomId}/leave")
-    public ResponseEntity<Void> leaveRoom(@PathVariable Long roomId,
+    @DeleteMapping("/{roomId}/quit")
+    public ResponseEntity<Void> quitRoom(@PathVariable Long roomId,
                                           @AuthUser User user) {
-        roomService.leaveRoom(roomId, user.getId());
+        roomService.quitRoom(roomId, user.getId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/chatchat/room/dto/request/QuitRoomRequest.java
+++ b/src/main/java/org/chatchat/room/dto/request/QuitRoomRequest.java
@@ -1,6 +1,6 @@
 package org.chatchat.room.dto.request;
 
-public record LeaveRoomRequest(
+public record QuitRoomRequest(
         Long roomId
 ) {
 }

--- a/src/main/java/org/chatchat/room/service/RoomQueryService.java
+++ b/src/main/java/org/chatchat/room/service/RoomQueryService.java
@@ -37,9 +37,15 @@ public class RoomQueryService {
         return PageResponseDto.of(roomResponses, roomPage.getNumber(), roomPage.getTotalPages());
     }
 
-    public Room findExistingRoomById(Long roomId) {
+    public Room findExistingRoomByRoomId(Long roomId) {
         return roomRepository.findById(roomId)
                 .orElseThrow(() -> new NotFoundException(ROOM_NOT_FOUND_ERROR));
+    }
+
+    public void validateExistingRoomByRoomId(Long roomId) {
+        if (!roomRepository.existsById(roomId)) {
+            throw new NotFoundException(ROOM_NOT_FOUND_ERROR);
+        }
     }
 
     public void validateExistingRoomByName(String roomName) {

--- a/src/main/java/org/chatchat/room/service/RoomService.java
+++ b/src/main/java/org/chatchat/room/service/RoomService.java
@@ -35,30 +35,30 @@ public class RoomService {
         Room room = new Room(name);
         Room savedRoom = roomRepository.save(room);
 
-        RoomUser roomUser = new RoomUser(savedRoom, user, user.getId());
-        roomUserService.saveChatPart(roomUser);
+        RoomUser roomUser = new RoomUser(savedRoom, user, user.getId(),0);
+        roomUserService.saveRoomUser(roomUser);
     }
 
     /**
      * 채팅방 초대
      */
     public void inviteUserToRoom(Long roomId, Long userId, String username) {
-        Room room = roomQueryService.findExistingRoomById(roomId);
+        Room room = roomQueryService.findExistingRoomByRoomId(roomId);
         // 이미 채팅방에 참여 중인 유저 검증
         roomUserQueryService.isUserMemberOfRoom(roomId, userId);
 
         // 초대할 유저
         User inviteUser = userQueryService.findExistingUserByName(username);
 
-        RoomUser roomUser = new RoomUser(room, inviteUser, userId);
-        roomUserService.saveChatPart(roomUser);
+        RoomUser roomUser = new RoomUser(room, inviteUser, userId,0);
+        roomUserService.saveRoomUser(roomUser);
     }
 
     /**
-     * 채팅방 나가기
+     * 채팅방 탈퇴
      */
-    public void leaveRoom(Long roomId, Long userId) {
-        RoomUser roomUser = roomUserQueryService.findExistingChatPart(roomId, userId);
-        roomUserService.removeChatPart(roomUser);
+    public void quitRoom(Long roomId, Long userId) {
+        RoomUser roomUser = roomUserQueryService.findExistingRoomUser(roomId, userId);
+        roomUserService.removeRoomUser(roomUser);
     }
 }

--- a/src/main/java/org/chatchat/room/util/RoomSessionManager.java
+++ b/src/main/java/org/chatchat/room/util/RoomSessionManager.java
@@ -1,0 +1,38 @@
+package org.chatchat.room.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class RoomSessionManager {
+
+    private Map<Long, String> userSessionMap = new ConcurrentHashMap<>(); // 사용자 ID와 세션 ID 매핑
+    private Map<String, String> sessionRoomMap = new ConcurrentHashMap<>(); // 세션 ID와 채팅방 ID 매핑
+
+    public void mapUserSession(Long userId, String sessionId) {
+        userSessionMap.put(userId, sessionId);
+    }
+
+    public void enterRoom(String sessionId, String roomId) {
+        sessionRoomMap.put(sessionId, roomId);
+    }
+
+    public void leaveRoom(String sessionId) {
+        sessionRoomMap.remove(sessionId);
+        userSessionMap.values().remove(sessionId);
+    }
+
+    public String getCurrentRoom(String sessionId) {
+        return sessionRoomMap.get(sessionId);
+    }
+
+    public String getSessionIdForUser(Long userId) {
+        return userSessionMap.get(userId);
+    }
+
+    public boolean isSessionInRoom(String sessionId, String roomId) {
+        return roomId.equals(sessionRoomMap.get(sessionId));
+    }
+}

--- a/src/main/java/org/chatchat/roomuser/controller/RoomUserController.java
+++ b/src/main/java/org/chatchat/roomuser/controller/RoomUserController.java
@@ -1,0 +1,45 @@
+package org.chatchat.roomuser.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.chatchat.chatmessage.dto.response.MessageResponse;
+import org.chatchat.chatmessage.service.ChatMessageQueryService;
+import org.chatchat.common.page.dto.response.PageResponseDto;
+import org.chatchat.roomuser.service.RoomUserService;
+import org.chatchat.security.auth.annotation.AuthUser;
+import org.chatchat.user.domain.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/rooms")
+@RequiredArgsConstructor
+public class RoomUserController {
+
+    private final RoomUserService roomUserService;
+    private final ChatMessageQueryService chatMessageQueryService;
+
+    // 채팅방 입장
+    @GetMapping("/{roomId}/enter")
+    public ResponseEntity<PageResponseDto<MessageResponse>> enterRoom(@PathVariable("roomId") Long roomId,
+                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                      @AuthUser User user,
+                                                                      HttpServletRequest request) {
+        // 세션 ID 추출
+        String sessionId = request.getSession().getId();
+        roomUserService.enterRoom(sessionId, roomId, user.getId());
+        PageResponseDto<MessageResponse> messages = chatMessageQueryService.loadMessagesByRoomId(roomId, user.getId(), page);
+        return ResponseEntity.ok(messages);
+    }
+
+    // 채팅방 나가기
+    @GetMapping("/{roomId}/leave")
+    public ResponseEntity<Void> leaveRoom(@PathVariable Long roomId,
+                                          @AuthUser User user,
+                                          HttpServletRequest request) {
+        // 세션 ID 추출
+        String sessionId = request.getSession().getId();
+        roomUserService.leaveRoom(sessionId, roomId, user.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/chatchat/roomuser/domain/RoomUser.java
+++ b/src/main/java/org/chatchat/roomuser/domain/RoomUser.java
@@ -27,4 +27,15 @@ public class RoomUser extends BaseEntity {
 
     @Column
     private Long inviter;
+
+    @Column
+    private int count;
+
+    public void incrementCount() {
+        this.count += 1;
+    }
+
+    public void resetCount() {
+        this.count = 0;
+    }
 }

--- a/src/main/java/org/chatchat/roomuser/domain/repository/RoomUserRepository.java
+++ b/src/main/java/org/chatchat/roomuser/domain/repository/RoomUserRepository.java
@@ -3,6 +3,7 @@ package org.chatchat.roomuser.domain.repository;
 import org.chatchat.roomuser.domain.RoomUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomUserRepository extends JpaRepository<RoomUser, Long> {
@@ -10,4 +11,6 @@ public interface RoomUserRepository extends JpaRepository<RoomUser, Long> {
     boolean existsByRoomIdAndUserId(Long roomId, Long userId);
 
     Optional<RoomUser> findByRoomIdAndUserId(Long roomId, Long userId);
+
+    List<RoomUser> findByRoomId(Long roomId);
 }

--- a/src/main/java/org/chatchat/roomuser/service/RoomUserQueryService.java
+++ b/src/main/java/org/chatchat/roomuser/service/RoomUserQueryService.java
@@ -6,6 +6,8 @@ import org.chatchat.roomuser.domain.repository.RoomUserRepository;
 import org.chatchat.common.exception.ForbiddenException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 import static org.chatchat.common.exception.type.ErrorType.NOT_ROOM_MEMBER_ERROR;
 
 @Service
@@ -20,8 +22,12 @@ public class RoomUserQueryService {
         }
     }
 
-    public RoomUser findExistingChatPart(Long roomId, Long userId) {
+    public RoomUser findExistingRoomUser(Long roomId, Long userId) {
         return roomUserRepository.findByRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new ForbiddenException(NOT_ROOM_MEMBER_ERROR));
+    }
+
+    public List<RoomUser> findExistingRoomUserListByRoomId(Long roomId) {
+        return roomUserRepository.findByRoomId(roomId);
     }
 }

--- a/src/main/java/org/chatchat/roomuser/service/RoomUserService.java
+++ b/src/main/java/org/chatchat/roomuser/service/RoomUserService.java
@@ -1,10 +1,14 @@
 package org.chatchat.roomuser.service;
 
 import lombok.RequiredArgsConstructor;
+import org.chatchat.room.service.RoomQueryService;
+import org.chatchat.room.util.RoomSessionManager;
 import org.chatchat.roomuser.domain.RoomUser;
 import org.chatchat.roomuser.domain.repository.RoomUserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -12,12 +16,60 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoomUserService {
 
     private final RoomUserRepository roomUserRepository;
+    private final RoomUserQueryService roomUserQueryService;
+    private final RoomQueryService roomQueryService;
+    private final RoomSessionManager roomSessionManager;
 
-    public void saveChatPart(final RoomUser roomUser) {
+    public void saveRoomUser(final RoomUser roomUser) {
         roomUserRepository.save(roomUser);
     }
 
-    public void removeChatPart(final RoomUser roomUser) {
+    public void removeRoomUser(final RoomUser roomUser) {
         roomUserRepository.delete(roomUser);
+    }
+
+    public void increaseUnreadMessageCount(Long roomId, String senderName) {
+        List<RoomUser> roomUsers = roomUserQueryService.findExistingRoomUserListByRoomId(roomId);
+
+        // 읽지 않은 메세지 수를 증가시킬 사용자들
+        List<RoomUser> usersToUpdate = roomUsers.stream()
+                .filter(roomUser -> !roomUser.getUser().getUsername().equals(senderName))
+                .filter(roomUser -> {
+                    String sessionId = roomSessionManager.getSessionIdForUser(roomUser.getUser().getId());
+                    return sessionId == null || !roomSessionManager.isSessionInRoom(sessionId, String.valueOf(roomId));
+                })
+                .toList();
+        // 읽지 않은 메세지 수 증가 처리
+        usersToUpdate.forEach(RoomUser::incrementCount);
+
+        roomUserRepository.saveAll(usersToUpdate);
+    }
+
+    /**
+     * 채팅방 입장
+     */
+    public void enterRoom(String sessionId, Long roomId, Long userId) {
+        // 채팅방에 입장 처리
+        roomSessionManager.enterRoom(sessionId, roomId.toString());
+        roomSessionManager.mapUserSession(userId, sessionId);
+
+        roomQueryService.validateExistingRoomByRoomId(roomId);
+        RoomUser roomUser = roomUserQueryService.findExistingRoomUser(roomId, userId);
+        // 안읽은 채팅 개수 0개로 초기화
+        roomUser.resetCount();
+        saveRoomUser(roomUser);
+    }
+
+    /**
+     * 채팅방 나가기
+     */
+    public void leaveRoom(String sessionId, Long roomId, Long userId) {
+        String sessionRoomId = roomSessionManager.getCurrentRoom(sessionId);
+        if (sessionRoomId != null && sessionRoomId.equals(roomId.toString())) {
+            roomSessionManager.leaveRoom(sessionId);
+            RoomUser roomUser = roomUserQueryService.findExistingRoomUser(Long.valueOf(sessionRoomId), userId);
+            roomUser.incrementCount();
+            roomUserRepository.save(roomUser);
+        }
     }
 }


### PR DESCRIPTION
## Description
- 채팅방별 읽지 않은 채팅 메세지 수 카운트 기능 구현
- 채팅방 입장, 나가기 기능 구현
## Changes
### Domain
- [x] RoomUser
### Controller
- [x] RoomUserController
### Service
- [x] RoomUserService
### Util
- [x] RoomSessionManager
## Additional context
- 채팅방 입장 시 읽음으로 처리 -> 0개로 초기화
- 채팅방 입장 시 HashMap에 UserId : SessionId, SessionId : RoomId 를 저장하여 유저가 현재 입장해있는 채팅방 정보를 저장한다.
- 채팅방 나가기 시 저장된 SessionId 어떤 유저가 어떤 방에 머물러있었는지 정보를 삭제한다.
- 하지만 현재 ConcurrentHashMap을 사용하여 유저의 정보를 저장하고 있으므로 서버를 재실행하면 이전에 입장했던 map 정보가 사라진다. -> Redis 를 활용하여 별도의 캐시 메모리 DB를 사용하여 예외상황을 줄일 수 있을 것 같다.
Closes #45 
Closes #46 