### PR TITLE
Feature/#48, #49, #50 Kafka 설정 및 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
 	// WebSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/chatchat/chatmessage/controller/ChatMessageController.java
+++ b/src/main/java/org/chatchat/chatmessage/controller/ChatMessageController.java
@@ -2,7 +2,6 @@ package org.chatchat.chatmessage.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.chatchat.chatmessage.dto.request.MessageRequest;
-import org.chatchat.chatmessage.dto.response.MessageResponse;
 import org.chatchat.chatmessage.service.ChatMessageService;
 import org.chatchat.room.dto.request.InviteUserToRoomRequest;
 import org.chatchat.room.dto.request.QuitRoomRequest;
@@ -11,7 +10,6 @@ import org.chatchat.common.exception.type.ErrorType;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -19,27 +17,23 @@ import org.springframework.stereotype.Controller;
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
-    private final SimpMessageSendingOperations messagingTemplate;
 
     @MessageMapping("/chat.sendMessage")
-    public void sendTalkMessage(@Payload MessageRequest messageRequest, SimpMessageHeaderAccessor headerAccessor) {
+    public void sendTalkMessage(@Payload MessageRequest messageRequest,SimpMessageHeaderAccessor headerAccessor) {
         String username = extractUsername(headerAccessor);
-        MessageResponse messageResponse = chatMessageService.saveTalkMessage(messageRequest, username);
-        messagingTemplate.convertAndSend("/topic/room." + messageRequest.roomId(), messageResponse);
+        chatMessageService.saveAndSendChatMessage(messageRequest,username);
     }
 
     @MessageMapping("/chat.sendInviteMessage")
     public void sendInviteMessage(@Payload InviteUserToRoomRequest inviteUserToRoomRequest, SimpMessageHeaderAccessor headerAccessor) {
         String username = extractUsername(headerAccessor);
-        MessageResponse messageResponse = chatMessageService.saveInviteMessage(inviteUserToRoomRequest, username);
-        messagingTemplate.convertAndSend("/topic/room." + inviteUserToRoomRequest.roomId(), messageResponse);
+        chatMessageService.sendInviteMessage(inviteUserToRoomRequest,username);
     }
 
     @MessageMapping("/chat.sendQuitMessage")
-    public void sendLeaveMessage(@Payload QuitRoomRequest quitRoomRequest, SimpMessageHeaderAccessor headerAccessor) {
+    public void sendQuitMessage(@Payload QuitRoomRequest quitRoomRequest, SimpMessageHeaderAccessor headerAccessor) {
         String username = extractUsername(headerAccessor);
-        MessageResponse messageResponse = chatMessageService.saveQuitMessage(quitRoomRequest, username);
-        messagingTemplate.convertAndSend("/topic/room." + quitRoomRequest.roomId(), messageResponse);
+        chatMessageService.sendQuitMessage(quitRoomRequest,username);
     }
 
     private String extractUsername(SimpMessageHeaderAccessor headerAccessor) {

--- a/src/main/java/org/chatchat/chatmessage/dto/response/MessageResponse.java
+++ b/src/main/java/org/chatchat/chatmessage/dto/response/MessageResponse.java
@@ -1,6 +1,7 @@
 package org.chatchat.chatmessage.dto.response;
 
 import org.chatchat.chatmessage.domain.ChatMessage;
+import org.chatchat.kafka.domain.KafkaMessage;
 
 import java.time.format.DateTimeFormatter;
 
@@ -11,13 +12,23 @@ public record MessageResponse(
         String content,
         String sentAt
 ) {
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("MM-dd HH:mm");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
-    public static MessageResponse from(ChatMessage message) {
+    public static MessageResponse fromChatMessage(ChatMessage message) {
         return new MessageResponse(
                 message.getId(),
                 message.getRoomId(),
                 message.getSender(),
+                message.getContent(),
+                FORMATTER.format(message.getSentAt())
+        );
+    }
+
+    public static MessageResponse fromKafkaMessage(KafkaMessage message) {
+        return new MessageResponse(
+                message.getId(),
+                message.getRoomId(),
+                message.getSenderName(),
                 message.getContent(),
                 FORMATTER.format(message.getSentAt())
         );

--- a/src/main/java/org/chatchat/chatmessage/service/ChatMessageQueryService.java
+++ b/src/main/java/org/chatchat/chatmessage/service/ChatMessageQueryService.java
@@ -32,7 +32,7 @@ public class ChatMessageQueryService {
         Page<ChatMessage> messagePage = chatMessageRepository.findByRoomIdOrderBySentAtDesc(String.valueOf(roomId), pageable);
         List<MessageResponse> messageResponses = messagePage.getContent()
                 .stream()
-                .map(MessageResponse::from)
+                .map(MessageResponse::fromChatMessage)
                 .toList();
 
         return PageResponseDto.of(messageResponses, messagePage.getNumber(), messagePage.getTotalPages());

--- a/src/main/java/org/chatchat/chatmessage/util/WebSocketEventListener.java
+++ b/src/main/java/org/chatchat/chatmessage/util/WebSocketEventListener.java
@@ -2,12 +2,8 @@ package org.chatchat.chatmessage.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.chatchat.common.exception.InternalServerException;
-import org.chatchat.common.exception.UnauthorizedException;
-import org.chatchat.common.exception.type.ErrorType;
+import org.chatchat.kafka.service.KafkaConsumerService;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
@@ -17,31 +13,31 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 @RequiredArgsConstructor
 public class WebSocketEventListener {
 
+    private final KafkaConsumerService kafkaConsumerService;
+    private final WebSocketTracker webSocketTracker;
+
     // 웹소켓 연결 시 호출되는 메서드
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
         log.info("새로운 웹소켓 연결이 있습니다.");
-        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap((Message<?>) event.getMessage().getHeaders().get("simpConnectMessage"));
-        try {
-            String username = (String) headerAccessor.getSessionAttributes().get("username");
-            if (username == null) {
-                throw new UnauthorizedException(ErrorType.NO_AUTHORIZATION_ERROR, "세션에 username 이 비어있습니다.");
-            }
-        } catch (Exception e) {
-            throw new InternalServerException(ErrorType.INTERNAL_SERVER_ERROR, e.getMessage());
+        // 웹소켓 연결 시 사용자가 아무도 없을 경우
+        if (!webSocketTracker.hasActiveConnections()) {
+            // 카프카 컨슈머로서 구독 시작
+            kafkaConsumerService.startListening();
         }
+        // 사용자 추가
+        webSocketTracker.userConnected();
     }
 
     // 웹소켓 연결 해제 시 호출되는 메서드
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
-        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap((Message<?>) event.getMessage().getHeaders().get("simpConnectMessage"));
-        String username = (String) headerAccessor.getSessionAttributes().get("username");
-        Long roomId = (Long) headerAccessor.getSessionAttributes().get("roomId");
-        if (username != null) {
-            log.info(username + "님이 " + roomId + "번 방의 소켓 연결을 끊었습니다.");
-        } else {
-            log.info("세션에 username 이 비어있는 유저의 웹소켓 연결이 끊어졌습니다.");
+        // 웹소켓 종료 시 사용자 제거
+        webSocketTracker.userDisconnected();
+        // 웹소켓 연결한 사용자가 아무도 없을 경우
+        if (!webSocketTracker.hasActiveConnections()) {
+            // 카프카 구독 종료
+            kafkaConsumerService.stopListening();
         }
     }
 }

--- a/src/main/java/org/chatchat/chatmessage/util/WebSocketEventListener.java
+++ b/src/main/java/org/chatchat/chatmessage/util/WebSocketEventListener.java
@@ -2,11 +2,17 @@ package org.chatchat.chatmessage.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.chatchat.common.exception.InternalServerException;
 import org.chatchat.kafka.service.KafkaConsumerService;
 import org.springframework.context.event.EventListener;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import static org.chatchat.common.exception.type.ErrorType.WEBSOCKET_DISCONNECTED_ERROR;
 
 @Slf4j
 @Component
@@ -19,7 +25,10 @@ public class WebSocketEventListener {
     // 웹소켓 연결 시 호출되는 메서드
     @EventListener
     public void handleWebSocketConnectListener(SessionConnectedEvent event) {
-        log.info("새로운 웹소켓 연결이 있습니다.");
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap((Message<?>) event.getMessage().getHeaders().get("simpConnectMessage"));
+        String username = (String) headerAccessor.getSessionAttributes().get("username");
+        log.info("새로운 웹소켓 연결이 있습니다. 유저 : {}", username);
+
         // 웹소켓 연결 시 사용자가 아무도 없을 경우
         if (!webSocketTracker.hasActiveConnections()) {
             // 카프카 컨슈머로서 구독 시작
@@ -32,6 +41,18 @@ public class WebSocketEventListener {
     // 웹소켓 연결 해제 시 호출되는 메서드
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap((Message<?>) event.getMessage().getHeaders().get("simpConnectMessage"));
+        String username = (String) headerAccessor.getSessionAttributes().get("username");
+        SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headers.getSessionId();
+
+        // 연결이 비정상적으로 끊어진 경우
+        if (event.getCloseStatus() != null) {
+            log.error("웹소켓 연결이 비정상적으로 종료되었습니다. 세션 ID: {}, 유저 이름 : {}, 종료 코드: {}, 이유: {}",
+                    sessionId, username, event.getCloseStatus().getCode(), event.getCloseStatus().getReason());
+            throw new InternalServerException(WEBSOCKET_DISCONNECTED_ERROR);
+        }
+
         // 웹소켓 종료 시 사용자 제거
         webSocketTracker.userDisconnected();
         // 웹소켓 연결한 사용자가 아무도 없을 경우
@@ -39,5 +60,6 @@ public class WebSocketEventListener {
             // 카프카 구독 종료
             kafkaConsumerService.stopListening();
         }
+        log.info("웹소켓 연결이 종료되었습니다. 유저 : {}", username);
     }
 }

--- a/src/main/java/org/chatchat/chatmessage/util/WebSocketTracker.java
+++ b/src/main/java/org/chatchat/chatmessage/util/WebSocketTracker.java
@@ -1,0 +1,23 @@
+package org.chatchat.chatmessage.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class WebSocketTracker {
+
+    private AtomicInteger connectionCount = new AtomicInteger(0);
+
+    public void userConnected() {
+        connectionCount.incrementAndGet();
+    }
+
+    public void userDisconnected() {
+        connectionCount.decrementAndGet();
+    }
+
+    public boolean hasActiveConnections() {
+        return connectionCount.get() > 0;
+    }
+}

--- a/src/main/java/org/chatchat/common/exception/controller/ApiExceptionController.java
+++ b/src/main/java/org/chatchat/common/exception/controller/ApiExceptionController.java
@@ -1,5 +1,6 @@
 package org.chatchat.common.exception.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import org.chatchat.common.exception.ApiException;
 import org.chatchat.common.exception.BadRequestException;
@@ -74,7 +75,7 @@ public class ApiExceptionController {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiExceptionResponse.res(badRequestException));
     }
 
-    // HandlerMethodValidationException 예외를 처리하는 핸들러(요청 시 검증을 통과하지 못한 경우)
+    // HandlerMethodValidationException 예외를 처리하는 핸들러 (요청 시 검증을 통과하지 못한 경우)
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ResponseEntity<ApiExceptionResponse> handlerMethodValidationExceptionHandler(
             final HandlerMethodValidationException e) {
@@ -115,6 +116,17 @@ public class ApiExceptionController {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiExceptionResponse> handleHttpMessageNotReadableException(
             final HttpMessageNotReadableException e) {
+
+        BadRequestException badRequestException = new BadRequestException(
+                ErrorType.INVALID_REQUEST_FORMAT_ERROR, e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiExceptionResponse.res(badRequestException));
+    }
+
+    // JsonProcessingException 예외를 처리하는 핸들러
+    @ExceptionHandler(JsonProcessingException.class)
+    public ResponseEntity<ApiExceptionResponse> handleJsonProcessingException(JsonProcessingException e) {
+        log.error("Json processing error: {}", e.getMessage());
 
         BadRequestException badRequestException = new BadRequestException(
                 ErrorType.INVALID_REQUEST_FORMAT_ERROR, e.getMessage());

--- a/src/main/java/org/chatchat/common/exception/type/ErrorType.java
+++ b/src/main/java/org/chatchat/common/exception/type/ErrorType.java
@@ -49,6 +49,7 @@ public enum ErrorType {
 
     // Internal Server
     INTERNAL_SERVER_ERROR("INTERNAL_50000", "서버 내부 에러입니다."),
+    WEBSOCKET_DISCONNECTED_ERROR("INTERNAL_50001", "웹소켓 연결이 끊어졌습니다."),
 
     // Validation
     NOT_NULL_VALID_ERROR( "VALID_90000", "필수값이 누락되었습니다."),

--- a/src/main/java/org/chatchat/kafka/config/KafkaConfig.java
+++ b/src/main/java/org/chatchat/kafka/config/KafkaConfig.java
@@ -1,0 +1,57 @@
+package org.chatchat.kafka.config;
+
+
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-group");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(3);
+        factory.getContainerProperties().setPollTimeout(3000);
+        return factory;
+    }
+}

--- a/src/main/java/org/chatchat/kafka/domain/KafkaMessage.java
+++ b/src/main/java/org/chatchat/kafka/domain/KafkaMessage.java
@@ -1,0 +1,35 @@
+package org.chatchat.kafka.domain;
+
+import lombok.*;
+import org.chatchat.chatmessage.domain.ChatMessage;
+import org.chatchat.chatmessage.domain.MessageType;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaMessage implements Serializable {
+
+    private String id;
+    private String type;
+    private String roomId;
+    private String senderName;
+    private String content;
+    private LocalDateTime sentAt;
+
+    // Kafka 메시지를 MongoDB 저장용 ChatMessage 객체로 변환
+    public ChatMessage toChatMessage() {
+        return ChatMessage.builder()
+                .id(this.id)
+                .type(MessageType.valueOf(this.type))
+                .roomId(this.roomId)
+                .sender(this.senderName)
+                .content(this.content)
+                .sentAt(this.sentAt)
+                .build();
+    }
+}

--- a/src/main/java/org/chatchat/kafka/service/KafkaConsumerService.java
+++ b/src/main/java/org/chatchat/kafka/service/KafkaConsumerService.java
@@ -1,0 +1,45 @@
+package org.chatchat.kafka.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.chatchat.chatmessage.dto.response.MessageResponse;
+import org.chatchat.common.exception.InternalServerException;
+import org.chatchat.kafka.domain.KafkaMessage;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+import static org.chatchat.common.exception.type.ErrorType.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumerService {
+
+    private final ObjectMapper objectMapper;
+    private final SimpMessageSendingOperations messagingTemplate;
+    private final KafkaListenerEndpointRegistry endpointRegistry;
+
+    @KafkaListener(id = "dynamicListener", topics = {"chat-messages"}, groupId = "chat-group", autoStartup = "false")
+    public void listen(String messageJson) {
+        try {
+            KafkaMessage kafkaMessage = objectMapper.readValue(messageJson, KafkaMessage.class);
+            MessageResponse messageResponse = MessageResponse.fromKafkaMessage(kafkaMessage);
+            messagingTemplate.convertAndSend("/topic/room." + messageResponse.roomId(), messageResponse);
+        } catch (Exception e) {
+            throw new InternalServerException(INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+    public void startListening() {
+        endpointRegistry.getListenerContainer("dynamicListener").start();
+        log.info("------Start Listening------");
+    }
+
+    public void stopListening() {
+        endpointRegistry.getListenerContainer("dynamicListener").stop();
+        log.info("------stop Listening------");
+    }
+}

--- a/src/main/java/org/chatchat/kafka/service/KafkaProducerService.java
+++ b/src/main/java/org/chatchat/kafka/service/KafkaProducerService.java
@@ -1,0 +1,29 @@
+package org.chatchat.kafka.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.chatchat.common.exception.BadRequestException;
+import org.chatchat.kafka.domain.KafkaMessage;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+
+import static org.chatchat.common.exception.type.ErrorType.INVALID_REQUEST_FORMAT_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void sendMessage(String topic, KafkaMessage kafkaMessage) {
+        try {
+            String jsonMessage = objectMapper.writeValueAsString(kafkaMessage);
+            kafkaTemplate.send(topic, jsonMessage);
+        } catch (JsonProcessingException e) {
+            throw new BadRequestException(INVALID_REQUEST_FORMAT_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/chatchat/security/config/SecurityConfig.java
+++ b/src/main/java/org/chatchat/security/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package org.chatchat.common.config;
+package org.chatchat.security.config;
 
 
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## Description
- Kafka 설정 및 적용
- 웹소켓 연결 인원 파악을 위한 트랙커 추가
- ChatMessage 저장, 보내기 로직 변경
## Changes
### 설정 파일
- [x] docker-compose.yml 
- [x] application-local.yml
### Config
- [x] KafkaConfig
### Domain
- [x] KafkaMessage
### Controller
- [x] ChatMessageController
### Service
- [x] KafkaProducerService
- [x] KafkaConsumerService
- [x] ChatMessageService
### Util
- [x] WebSocketTracker
- [x] WebSocketEventListener
## Additional context
### 문제점
- STOMP를 사용하면 in-memory 브로커를 사용하게 되는데, 만약 여러 사용자가 동시에 메세지를 보낼 때 메세지의 순서가 보장되지 않는 문제가 있다.
- 수평확장을 통해 서버의 개수를 늘리면, 각 서버별로 다른 웹소켓에 연결된 사용자들이 존재하게 된다. 그럼 같은 채팅방을 구독하고 있어도 다른 웹소켓(다른 서버)에 연결된 사용자는 메세지를 받지 못한다.
- 또한 메모리 기반 처리이기에 확장성에 문제가 있다.
### 해결
- 외부 메세지 브로커인 kafka를 도입하여 메세지 순서를 보장하고, 많은 사용자들이 몰릴 경우에도 효율적으로 처리할 수 있다.
- 수평확장을 통해 서버의 개수를 늘려도 외부 브로커인 Kafka를 통해 메세징 처리를 하기 때문에 메세지 전달엔 문제가 없다.
Closes #48
Closes #49 
Closes #50 