### PR TITLE
Feature/#57 사용자별 채팅방 읽지 않은 메세지 갯수 반환 기능 구현

### DIFF
--- a/src/main/java/org/chatchat/room/dto/response/RoomInfoResponse.java
+++ b/src/main/java/org/chatchat/room/dto/response/RoomInfoResponse.java
@@ -2,6 +2,7 @@ package org.chatchat.room.dto.response;
 
 public record RoomInfoResponse(
         Long roomId,
-        String name
+        String name,
+        int unreadCount
 ) {
 }

--- a/src/main/java/org/chatchat/room/service/RoomService.java
+++ b/src/main/java/org/chatchat/room/service/RoomService.java
@@ -35,7 +35,7 @@ public class RoomService {
         Room room = new Room(name);
         Room savedRoom = roomRepository.save(room);
 
-        RoomUser roomUser = new RoomUser(savedRoom, user, user.getId(),0);
+        RoomUser roomUser = new RoomUser(savedRoom, user, user.getId(), 0);
         roomUserService.saveRoomUser(roomUser);
     }
 
@@ -50,7 +50,7 @@ public class RoomService {
         // 초대할 유저
         User inviteUser = userQueryService.findExistingUserByName(username);
 
-        RoomUser roomUser = new RoomUser(room, inviteUser, userId,0);
+        RoomUser roomUser = new RoomUser(room, inviteUser, userId, 0);
         roomUserService.saveRoomUser(roomUser);
     }
 

--- a/src/main/java/org/chatchat/roomuser/domain/RoomUser.java
+++ b/src/main/java/org/chatchat/roomuser/domain/RoomUser.java
@@ -45,4 +45,11 @@ public class RoomUser extends BaseEntity {
     public void updateLastReadMessageId(String messageId) {
         this.lastReadMessageId = messageId;
     }
+
+    public RoomUser(Room room, User user, Long inviter, int unreadCount) {
+        this.room = room;
+        this.user = user;
+        this.inviter = inviter;
+        this.unreadCount = unreadCount;
+    }
 }

--- a/src/main/java/org/chatchat/roomuser/domain/repository/RoomUserRepository.java
+++ b/src/main/java/org/chatchat/roomuser/domain/repository/RoomUserRepository.java
@@ -16,6 +16,9 @@ public interface RoomUserRepository extends JpaRepository<RoomUser, Long> {
 
     List<RoomUser> findByRoomId(Long roomId);
 
+    @Query("SELECT ru.unreadCount FROM RoomUser ru WHERE ru.room.id = :roomId AND ru.user.id = :userId")
+    int findUnreadMessagesCount(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
     @Query("SELECT COUNT(ru) FROM RoomUser ru WHERE ru.room.id = :roomId AND ru.lastReadMessageId < :messageId")
     Long countUnreadUsers(@Param("roomId") Long roomId, @Param("messageId") String messageId);
 }

--- a/src/main/java/org/chatchat/roomuser/service/RoomUserQueryService.java
+++ b/src/main/java/org/chatchat/roomuser/service/RoomUserQueryService.java
@@ -36,4 +36,8 @@ public class RoomUserQueryService {
     public Long countUnreadMessages(Long roomId, String messageId) {
         return roomUserRepository.countUnreadUsers(roomId, messageId);
     }
+
+    public int findUnreadMessagesCount(Long roomId, Long userId) {
+        return roomUserRepository.findUnreadMessagesCount(roomId, userId);
+    }
 }


### PR DESCRIPTION
## Description
- 사용자별 채팅방 읽지 않은 메세지 갯수 반환 기능 구현
## Changes
### Repository
- [x] RoomUserRepository
### Service
- [x] RoomService
- [x] RoomQueryService
- [x] RoomUserQueryService
### Dto
- [x] RoomInfoResponse
## Additional context
- 채팅방 전체 조회 시 각 채팅방별 읽지 않은 메세지 수를 함께 반환하도록 수정
Closes #57 